### PR TITLE
Use mvnw in shell script, include interrobang

### DIFF
--- a/package-no-tests.sh
+++ b/package-no-tests.sh
@@ -1,1 +1,3 @@
-mvn -Dmaven.test.skip=true package
+#!/usr/bin/env sh
+
+./mvnw -Dmaven.test.skip=true package


### PR DESCRIPTION
Since the `mvnw` is already being leveraged, it feels appropriate to have `package-no-tests.sh` use the `./mvnw` of the project.

This change also includes an interrobang line for the script. I can absolutely take that out if you'd like.